### PR TITLE
fixup! mbp: Permit accessing geometry ports pre-Finalize()

### DIFF
--- a/multibody/multibody_tree/multibody_plant/multibody_plant.cc
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.cc
@@ -250,6 +250,7 @@ geometry::SourceId MultibodyPlant<T>::RegisterAsSourceForSceneGraph(
   // purpose, it gets nullified at Finalize().
   scene_graph_ = scene_graph;
   body_index_to_frame_id_[world_index()] = scene_graph->world_frame_id();
+  DeclareSceneGraphPorts();
   return source_id_.value();
 }
 
@@ -539,9 +540,6 @@ void MultibodyPlant<T>::SetUpJointLimitsParameters() {
 template<typename T>
 void MultibodyPlant<T>::FinalizePlantOnly() {
   DeclareStateCacheAndPorts();
-  // Only declare ports to communicate with a SceneGraph if the plant is
-  // provided with a valid source id.
-  if (source_id_) DeclareSceneGraphPorts();
   scene_graph_ = nullptr;  // must not be used after Finalize().
   if (num_collision_geometries() > 0 &&
       penalty_method_contact_parameters_.time_scale < 0)
@@ -1617,18 +1615,25 @@ template <typename T>
 void MultibodyPlant<T>::DeclareSceneGraphPorts() {
   geometry_query_port_ =
       this->DeclareAbstractInputPort("geometry_query").get_index();
-  // This presupposes that the source id has been assigned and _all_ frames have
-  // been registered.
-  std::vector<FrameId> ids;
-  for (auto it : body_index_to_frame_id_) {
-    if (it.first == world_index()) continue;
-    ids.push_back(it.second);
-  }
-  geometry_pose_port_ =
-      this->DeclareAbstractOutputPort("geometry_pose",
-                                      FramePoseVector<T>(*source_id_, ids),
-                                      &MultibodyPlant::CalcFramePoseOutput)
-          .get_index();
+  // Allocate pose port.
+  typename systems::LeafOutputPort<T>::AllocCallback pose_alloc = [this]() {
+    // This presupposes that the source id has been assigned and _all_ frames
+    // have been registered.
+    std::vector<FrameId> ids;
+    for (auto it : this->body_index_to_frame_id_) {
+      if (it.first == world_index()) continue;
+      ids.push_back(it.second);
+    }
+    return systems::AbstractValue::Make(
+        FramePoseVector<T>(*this->source_id_, ids));
+  };
+  typename systems::LeafOutputPort<T>::CalcCallback pose_callback = [this](
+      const Context<T>& context, systems::AbstractValue* value) {
+    this->CalcFramePoseOutput(
+        context, &value->GetMutableValue<FramePoseVector<T>>());
+  };
+  geometry_pose_port_ = this->DeclareAbstractOutputPort(
+      "geometry_pose", pose_alloc, pose_callback).get_index();
 }
 
 template <typename T>
@@ -1661,7 +1666,6 @@ void MultibodyPlant<T>::CalcFramePoseOutput(
 template <typename T>
 const OutputPort<T>& MultibodyPlant<T>::get_geometry_poses_output_port()
 const {
-  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(geometry_source_is_registered());
   return systems::System<T>::get_output_port(geometry_pose_port_);
 }
@@ -1669,7 +1673,6 @@ const {
 template <typename T>
 const systems::InputPort<T>&
 MultibodyPlant<T>::get_geometry_query_input_port() const {
-  DRAKE_MBP_THROW_IF_NOT_FINALIZED();
   DRAKE_DEMAND(geometry_source_is_registered());
   return systems::System<T>::get_input_port(geometry_query_port_);
 }

--- a/multibody/multibody_tree/multibody_plant/multibody_plant.h
+++ b/multibody/multibody_tree/multibody_plant/multibody_plant.h
@@ -1036,14 +1036,12 @@ class MultibodyPlant : public MultibodyTreeSystem<T> {
   /// connection with a SceneGraph.
   /// @throws std::exception if this system was not registered with a
   /// SceneGraph.
-  /// @throws std::exception if called pre-finalize. See Finalize().
   const systems::InputPort<T>& get_geometry_query_input_port() const;
 
   /// Returns the output port of frames' poses to communicate with a
   /// SceneGraph.
   /// @throws std::exception if this system was not registered with a
   /// SceneGraph.
-  /// @throws std::exception if called pre-finalize. See Finalize().
   const systems::OutputPort<T>& get_geometry_poses_output_port() const;
   /// @}
 

--- a/multibody/multibody_tree/multibody_plant/test/box_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/box_test.cc
@@ -110,7 +110,9 @@ GTEST_TEST(Box, UnderStiction) {
   Context<double>& plant_context =
       diagram->GetMutableSubsystemContext(plant, diagram_context.get());
 
-  plant_context.FixInputPort(0, Vector1<double>::Constant(applied_force));
+  plant_context.FixInputPort(
+      plant.get_actuation_input_port().get_index(),
+      Vector1<double>::Constant(applied_force));
 
   Simulator<double> simulator(*diagram, std::move(diagram_context));
   simulator.set_publish_every_time_step(true);

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -577,13 +577,13 @@ TEST_F(AcrobotPlantTests, VisualGeometryRegistration) {
   unique_ptr<AbstractValue> poses_value =
       plant_->get_geometry_poses_output_port().Allocate();
   EXPECT_NO_THROW(poses_value->GetValueOrThrow<FramePoseVector<double>>());
+
+  // Compute the poses for each geometry in the model.
+  plant_->get_geometry_poses_output_port().Calc(*context, poses_value.get());
   const FramePoseVector<double>& poses =
       poses_value->GetValueOrThrow<FramePoseVector<double>>();
   EXPECT_EQ(poses.source_id(), plant_->get_source_id());
   EXPECT_EQ(poses.size(), 2);  // Only two frames move.
-
-  // Compute the poses for each geometry in the model.
-  plant_->get_geometry_poses_output_port().Calc(*context, poses_value.get());
 
   const MultibodyTree<double>& tree = plant_->tree();
   std::vector<Isometry3<double >> X_WB_all;
@@ -990,13 +990,13 @@ GTEST_TEST(MultibodyPlantTest, CollisionGeometryRegistration) {
   unique_ptr<AbstractValue> poses_value =
       plant.get_geometry_poses_output_port().Allocate();
   EXPECT_NO_THROW(poses_value->GetValueOrThrow<FramePoseVector<double>>());
+
+  // Compute the poses for each geometry in the model.
+  plant.get_geometry_poses_output_port().Calc(*context, poses_value.get());
   const FramePoseVector<double>& pose_data =
       poses_value->GetValueOrThrow<FramePoseVector<double>>();
   EXPECT_EQ(pose_data.source_id(), plant.get_source_id());
   EXPECT_EQ(pose_data.size(), 2);  // Only two frames move.
-
-  // Compute the poses for each geometry in the model.
-  plant.get_geometry_poses_output_port().Calc(*context, poses_value.get());
 
   const MultibodyTree<double>& model = plant.tree();
   std::vector<Isometry3<double >> X_WB_all;

--- a/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
+++ b/multibody/multibody_tree/multibody_plant/test/multibody_plant_test.cc
@@ -277,14 +277,6 @@ class AcrobotPlantTests : public ::testing::Test {
     // it.
     DRAKE_DEMAND(plant_->get_source_id() != nullopt);
 
-    // Verify that methods with pre-Finalize() conditions throw accordingly.
-    DRAKE_EXPECT_THROWS_MESSAGE(
-        plant_->get_geometry_poses_output_port(),
-        std::logic_error,
-        /* Verify this method is throwing for the right reasons. */
-        "Pre-finalize calls to '.*' are not allowed; "
-        "you must call Finalize\\(\\) first.");
-
     DRAKE_EXPECT_THROWS_MESSAGE(
         plant_->get_continuous_state_output_port(),
         std::logic_error,


### PR DESCRIPTION
I'll propose that this amendment keeps the problematic boilerplate better contained, less of a regression from master.