### PR TITLE
fixup! mbp: Use MBP+SG sugar in a small set of examples

### DIFF
--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -1035,10 +1035,10 @@ void init_multibody_plant(py::module m) {
         py::object builder_py = py::cast(builder, py_reference);
         // Keep alive, ownership: `plant` keeps `builder` alive.
         py::object plant_py =
-            py::cast(pair.first, py_reference_internal, builder_py);
+            py::cast(pair.plant, py_reference_internal, builder_py);
         // Keep alive, ownership: `scene_graph` keeps `builder` alive.
         py::object scene_graph_py =
-            py::cast(pair.second, py_reference_internal, builder_py);
+            py::cast(pair.scene_graph, py_reference_internal, builder_py);
         return py::make_tuple(plant_py, scene_graph_py);
       },
       py::arg("builder"), py::arg("plant") = nullptr,

--- a/bindings/pydrake/multibody/multibody_tree_py.cc
+++ b/bindings/pydrake/multibody/multibody_tree_py.cc
@@ -1024,6 +1024,25 @@ void init_multibody_plant(py::module m) {
         .def("contact_info", &Class::contact_info, py::arg("i"));
     pysystems::AddValueInstantiation<Class>(m);
   }
+
+  m.def("AddMultibodyPlantSceneGraph",
+      [](systems::DiagramBuilder<T>* builder,
+          std::unique_ptr<MultibodyPlant<T>> plant,
+          std::unique_ptr<SceneGraph<T>> scene_graph) {
+        auto pair = AddMultibodyPlantSceneGraph(
+            builder, std::move(plant), std::move(scene_graph));
+        // Must do manual keep alive to dig into tuple.
+        py::object builder_py = py::cast(builder, py_reference);
+        // Keep alive, ownership: `plant` keeps `builder` alive.
+        py::object plant_py =
+            py::cast(pair.first, py_reference_internal, builder_py);
+        // Keep alive, ownership: `scene_graph` keeps `builder` alive.
+        py::object scene_graph_py =
+            py::cast(pair.second, py_reference_internal, builder_py);
+        return py::make_tuple(plant_py, scene_graph_py);
+      },
+      py::arg("builder"), py::arg("plant") = nullptr,
+      py::arg("scene_graph") = nullptr, doc.AddMultibodyPlantSceneGraph.doc);
 }  // NOLINT(readability/fn_size)
 
 void init_parsing_deprecated(py::module m) {

--- a/bindings/pydrake/multibody/test/multibody_tree_test.py
+++ b/bindings/pydrake/multibody/test/multibody_tree_test.py
@@ -26,6 +26,7 @@ from pydrake.multibody.multibody_tree.math import (
     SpatialVelocity,
 )
 from pydrake.multibody.multibody_tree.multibody_plant import (
+    AddMultibodyPlantSceneGraph,
     ContactResults,
     MultibodyPlant,
     PointPairContactInfo,
@@ -81,20 +82,6 @@ def get_index_class(cls):
         if issubclass(cls, key_cls):
             return index_cls
     raise RuntimeError("Unknown class: {}".format(cls))
-
-
-def add_plant_and_scene_graph(builder):
-    # TODO(eric.cousineau): Hoist to C++.
-    plant = builder.AddSystem(MultibodyPlant())
-    scene_graph = builder.AddSystem(SceneGraph())
-    plant.RegisterAsSourceForSceneGraph(scene_graph)
-    builder.Connect(
-        scene_graph.get_query_output_port(),
-        plant.get_geometry_query_input_port())
-    builder.Connect(
-        plant.get_geometry_poses_output_port(),
-        scene_graph.get_source_pose_port(plant.get_source_id()))
-    return plant, scene_graph
 
 
 class TestMultibodyTreeMath(unittest.TestCase):
@@ -828,7 +815,7 @@ class TestMultibodyTree(unittest.TestCase):
 
     def test_scene_graph_queries(self):
         builder = DiagramBuilder()
-        plant, scene_graph = add_plant_and_scene_graph(builder)
+        plant, scene_graph = AddMultibodyPlantSceneGraph(builder)
         parser = Parser(plant=plant, scene_graph=scene_graph)
         parser.AddModelFromFile(
             FindResourceOrThrow(

--- a/bindings/pydrake/systems/test/meshcat_visualizer_test.py
+++ b/bindings/pydrake/systems/test/meshcat_visualizer_test.py
@@ -5,7 +5,8 @@ import numpy as np
 from pydrake.common import FindResourceOrThrow
 from pydrake.geometry import SceneGraph
 from pydrake.multibody.multibody_tree import UniformGravityFieldElement
-from pydrake.multibody.multibody_tree.multibody_plant import MultibodyPlant
+from pydrake.multibody.multibody_tree.multibody_plant import (
+    AddMultibodyPlantSceneGraph)
 from pydrake.multibody.parsing import Parser
 from pydrake.systems.analysis import Simulator
 from pydrake.systems.framework import DiagramBuilder
@@ -19,17 +20,11 @@ class TestMeshcat(unittest.TestCase):
             "drake/examples/multibody/cart_pole/cart_pole.sdf")
 
         builder = DiagramBuilder()
-        scene_graph = builder.AddSystem(SceneGraph())
-        cart_pole = builder.AddSystem(MultibodyPlant())
-        parser = Parser(plant=cart_pole, scene_graph=scene_graph)
-        parser.AddModelFromFile(file_name)
+        cart_pole, scene_graph = AddMultibodyPlantSceneGraph(builder)
+        Parser(plant=cart_pole).AddModelFromFile(file_name)
         cart_pole.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-        cart_pole.Finalize(scene_graph)
+        cart_pole.Finalize()
         assert cart_pole.geometry_source_is_registered()
-
-        builder.Connect(
-            cart_pole.get_geometry_poses_output_port(),
-            scene_graph.get_source_pose_port(cart_pole.get_source_id()))
 
         visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
                                                          zmq_url=None,
@@ -61,17 +56,10 @@ class TestMeshcat(unittest.TestCase):
             "drake/manipulation/models/iiwa_description/sdf/"
             "iiwa14_no_collision.sdf")
         builder = DiagramBuilder()
-        scene_graph = builder.AddSystem(SceneGraph())
-        kuka = builder.AddSystem(MultibodyPlant())
-        parser = Parser(plant=kuka, scene_graph=scene_graph)
-        parser.AddModelFromFile(file_name)
+        kuka, scene_graph = AddMultibodyPlantSceneGraph(builder)
+        Parser(plant=kuka).AddModelFromFile(file_name)
         kuka.AddForceElement(UniformGravityFieldElement([0, 0, -9.81]))
-        kuka.Finalize(scene_graph)
-        assert kuka.geometry_source_is_registered()
-
-        builder.Connect(
-            kuka.get_geometry_poses_output_port(),
-            scene_graph.get_source_pose_port(kuka.get_source_id()))
+        kuka.Finalize()
 
         visualizer = builder.AddSystem(MeshcatVisualizer(scene_graph,
                                                          zmq_url=None,

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -60,8 +60,7 @@ int do_main() {
 
   auto pair = AddMultibodyPlantSceneGraph(
       &builder, std::make_unique<MultibodyPlant<double>>(FLAGS_time_step));
-  MultibodyPlant<double>& plant = *pair.first;
-  SceneGraph<double>& scene_graph = *pair.second;
+  MultibodyPlant<double>& plant = pair.plant;
   AddInclinedPlaneToPlant(
       radius, mass, slope, surface_friction, g, &plant);
   plant.Finalize();
@@ -72,7 +71,7 @@ int do_main() {
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
 
-  geometry::ConnectDrakeVisualizer(&builder, scene_graph);
+  geometry::ConnectDrakeVisualizer(&builder, pair.scene_graph);
   auto diagram = builder.Build();
 
   // Create a context for this system:

--- a/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
+++ b/examples/multibody/inclined_plane/inclined_plane_run_dynamics.cc
@@ -14,7 +14,7 @@
 namespace drake {
 namespace examples {
 namespace multibody {
-namespace bouncing_ball {
+namespace inclined_plane {
 namespace {
 
 DEFINE_double(target_realtime_rate, 1.0,
@@ -40,16 +40,13 @@ using geometry::SourceId;
 using lcm::DrakeLcm;
 
 // "multibody" namespace is ambiguous here without "drake::".
-using drake::multibody::benchmarks::inclined_plane::MakeInclinedPlanePlant;
+using drake::multibody::benchmarks::inclined_plane::AddInclinedPlaneToPlant;
 using drake::multibody::CoulombFriction;
 using drake::multibody::MultibodyPlant;
 using drake::multibody::MultibodyTree;
 
 int do_main() {
   systems::DiagramBuilder<double> builder;
-
-  SceneGraph<double>& scene_graph = *builder.AddSystem<SceneGraph>();
-  scene_graph.set_name("scene_graph");
 
   // Plant's parameters.
   const double radius = 0.05;   // m
@@ -60,25 +57,20 @@ int do_main() {
                                                  FLAGS_dynamic_friction);
 
   DRAKE_DEMAND(FLAGS_time_step >= 0);
-  MultibodyPlant<double>& plant = *builder.AddSystem(MakeInclinedPlanePlant(
-      radius, mass, slope, surface_friction, g, FLAGS_time_step, &scene_graph));
-  const MultibodyTree<double>& tree = plant.tree();
+
+  auto pair = AddMultibodyPlantSceneGraph(
+      &builder, std::make_unique<MultibodyPlant<double>>(FLAGS_time_step));
+  MultibodyPlant<double>& plant = *pair.first;
+  SceneGraph<double>& scene_graph = *pair.second;
+  AddInclinedPlaneToPlant(
+      radius, mass, slope, surface_friction, g, &plant);
+  plant.Finalize();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(1.0e-5);
   plant.set_stiction_tolerance(FLAGS_stiction_tolerance);
 
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
-
-  // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!plant.get_source_id());
-
-  builder.Connect(scene_graph.get_query_output_port(),
-                  plant.get_geometry_query_input_port());
-
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
 
   geometry::ConnectDrakeVisualizer(&builder, scene_graph);
   auto diagram = builder.Build();
@@ -92,7 +84,7 @@ int do_main() {
 
   // This will set a default initial condition with the sphere located at
   // p_WBcm = (0; 0; 0) and zero spatial velocity.
-  tree.SetDefaultContext(&plant_context);
+  plant.SetDefaultContext(&plant_context);
 
   systems::Simulator<double> simulator(*diagram, std::move(diagram_context));
 
@@ -109,7 +101,7 @@ int do_main() {
 }
 
 }  // namespace
-}  // namespace bouncing_ball
+}  // namespace inclined_plane
 }  // namespace multibody
 }  // namespace examples
 }  // namespace drake
@@ -121,5 +113,5 @@ int main(int argc, char* argv[]) {
       "Launch drake-visualizer before running this example.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   drake::logging::HandleSpdlogGflags();
-  return drake::examples::multibody::bouncing_ball::do_main();
+  return drake::examples::multibody::inclined_plane::do_main();
 }

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.cc
@@ -13,22 +13,16 @@ using geometry::SceneGraph;
 using geometry::Sphere;
 using Eigen::AngleAxisd;
 
-std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
+void AddInclinedPlaneToPlant(
     double radius, double mass, double slope,
     const CoulombFriction<double>& surface_friction, double gravity,
-    double time_step,
-    SceneGraph<double>* scene_graph) {
-  DRAKE_THROW_UNLESS(scene_graph != nullptr);
-  DRAKE_THROW_UNLESS(time_step >= 0);
-
-  auto plant = std::make_unique<MultibodyPlant<double>>(time_step);
+    MultibodyPlant<double>* plant) {
+  DRAKE_THROW_UNLESS(plant != nullptr);
 
   UnitInertia<double> G_Bcm = UnitInertia<double>::SolidSphere(radius);
   SpatialInertia<double> M_Bcm(mass, Vector3<double>::Zero(), G_Bcm);
 
   const RigidBody<double>& ball = plant->AddRigidBody("Ball", M_Bcm);
-
-  plant->RegisterAsSourceForSceneGraph(scene_graph);
 
   // Orientation of a plane frame P with its z axis normal to the plane and its
   // x axis pointing down the plane.
@@ -89,11 +83,6 @@ std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
   // Gravity acting in the -z direction.
   plant->AddForceElement<UniformGravityFieldElement>(
       -gravity * Vector3<double>::UnitZ());
-
-  // We are done creating the plant.
-  plant->Finalize();
-
-  return plant;
 }
 
 }  // namespace inclined_plane

--- a/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.h
+++ b/multibody/benchmarks/inclined_plane/make_inclined_plane_plant.h
@@ -10,8 +10,7 @@ namespace multibody {
 namespace benchmarks {
 namespace inclined_plane {
 
-/// This method makes a MultibodyPlant model for a sphere rolling down an
-/// inclined plane.
+/// This method adds a sphere rolling down an inclined plane.
 ///
 /// @param[in] radius
 ///   The radius in meters of the sphere.
@@ -24,21 +23,15 @@ namespace inclined_plane {
 ///   surface properties for both the inclined plane and the sphere.
 /// @param[in] gravity
 ///   The acceleration of gravity, in m/s². Points in the minus z direction.
-/// @param[in] time_step
-///   If `time_step = 0`, the plant is modeled as a continuous system. Otherwise
-///   when `time_step > 0` the plant is modeled as a discrete system with
-///   periodic updates of period `time_step`. `time_step` must be non-negative.
-/// @param scene_graph
-///   This factory method will register the new multibody plant to be a source
-///   for this geometry system and it will also register geometry for contact
-///   modeling.
-/// @throws std::exception if time_step is negative.
-/// @throws std::exception if scene_graph is nullptr.
-std::unique_ptr<MultibodyPlant<double>> MakeInclinedPlanePlant(
+/// @param[out] plant
+///   Plant to contain the sphere and plane.
+/// @throws std::exception if plant is nullptr.
+/// @pre plant must be registered with a scene graph.
+void AddInclinedPlaneToPlant(
     double radius, double mass, double slope,
     const CoulombFriction<double>& surface_friction,
-    double gravity, double time_step,
-    geometry::SceneGraph<double>* scene_graph);
+    double gravity,
+    MultibodyPlant<double>* plant);
 
 }  // namespace inclined_plane
 }  // namespace benchmarks

--- a/multibody/plant/BUILD.bazel
+++ b/multibody/plant/BUILD.bazel
@@ -53,6 +53,7 @@ drake_cc_library(
         "//geometry:scene_graph",
         "//math:orthonormal_basis",
         "//multibody/tree",
+        "//systems/framework:diagram_builder",
         "//systems/framework:leaf_system",
     ],
 )

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1772,7 +1772,7 @@ T MultibodyPlant<T>::StribeckModel::step5(const T& x) {
 }
 
 template <typename T>
-std::pair<MultibodyPlant<T>*, geometry::SceneGraph<T>*>
+AddMultibodyPlantSceneGraphResult<T>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<T>* builder,
     std::unique_ptr<MultibodyPlant<T>> plant,
@@ -1801,14 +1801,14 @@ AddMultibodyPlantSceneGraph(
 
 // Add explicit instantiations for `AddMultibodyPlantSceneGraph`.
 template
-std::pair<MultibodyPlant<double>*, geometry::SceneGraph<double>*>
+AddMultibodyPlantSceneGraphResult<double>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<double>* builder,
     std::unique_ptr<MultibodyPlant<double>> plant,
     std::unique_ptr<geometry::SceneGraph<double>> scene_graph);
 
 template
-std::pair<MultibodyPlant<AutoDiffXd>*, geometry::SceneGraph<AutoDiffXd>*>
+AddMultibodyPlantSceneGraphResult<AutoDiffXd>
 AddMultibodyPlantSceneGraph(
     systems::DiagramBuilder<AutoDiffXd>* builder,
     std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant,
@@ -1819,3 +1819,5 @@ AddMultibodyPlantSceneGraph(
 
 DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
     class drake::multibody::MultibodyPlant)
+DRAKE_DEFINE_CLASS_TEMPLATE_INSTANTIATIONS_ON_DEFAULT_NONSYMBOLIC_SCALARS(
+    class drake::multibody::AddMultibodyPlantSceneGraphResult)

--- a/multibody/plant/multibody_plant.cc
+++ b/multibody/plant/multibody_plant.cc
@@ -1771,6 +1771,49 @@ T MultibodyPlant<T>::StribeckModel::step5(const T& x) {
   return x3 * (10 + x * (6 * x - 15));  // 10x³ - 15x⁴ + 6x⁵
 }
 
+template <typename T>
+std::pair<MultibodyPlant<T>*, geometry::SceneGraph<T>*>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder,
+    std::unique_ptr<MultibodyPlant<T>> plant,
+    std::unique_ptr<geometry::SceneGraph<T>> scene_graph) {
+  DRAKE_DEMAND(builder != nullptr);
+  if (!plant) {
+    plant = std::make_unique<MultibodyPlant<T>>();
+    plant->set_name("plant");
+  }
+  if (!scene_graph) {
+    scene_graph = std::make_unique<geometry::SceneGraph<T>>();
+    scene_graph->set_name("scene_graph");
+  }
+  auto* plant_ptr = builder->AddSystem(std::move(plant));
+  auto* scene_graph_ptr = builder->AddSystem(std::move(scene_graph));
+  plant_ptr->RegisterAsSourceForSceneGraph(scene_graph_ptr);
+  builder->Connect(
+      plant_ptr->get_geometry_poses_output_port(),
+      scene_graph_ptr->get_source_pose_port(
+          plant_ptr->get_source_id().value()));
+  builder->Connect(
+      scene_graph_ptr->get_query_output_port(),
+      plant_ptr->get_geometry_query_input_port());
+  return {plant_ptr, scene_graph_ptr};
+}
+
+// Add explicit instantiations for `AddMultibodyPlantSceneGraph`.
+template
+std::pair<MultibodyPlant<double>*, geometry::SceneGraph<double>*>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<double>* builder,
+    std::unique_ptr<MultibodyPlant<double>> plant,
+    std::unique_ptr<geometry::SceneGraph<double>> scene_graph);
+
+template
+std::pair<MultibodyPlant<AutoDiffXd>*, geometry::SceneGraph<AutoDiffXd>*>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<AutoDiffXd>* builder,
+    std::unique_ptr<MultibodyPlant<AutoDiffXd>> plant,
+    std::unique_ptr<geometry::SceneGraph<AutoDiffXd>> scene_graph);
+
 }  // namespace multibody
 }  // namespace drake
 

--- a/multibody/plant/multibody_plant.h
+++ b/multibody/plant/multibody_plant.h
@@ -21,6 +21,7 @@
 #include "drake/multibody/tree/rigid_body.h"
 #include "drake/multibody/tree/uniform_gravity_field_element.h"
 #include "drake/multibody/tree/weld_joint.h"
+#include "drake/systems/framework/diagram_builder.h"
 #include "drake/systems/framework/leaf_system.h"
 #include "drake/systems/framework/scalar_conversion_traits.h"
 
@@ -3164,6 +3165,25 @@ using MultibodyPlant
     = ::drake::multibody::MultibodyPlant<T>;
 }  // namespace multibody_plant
 #endif  // DRAKE_DOXYGEN_CXX
+
+/// Adds a MultibodyPlant and a SceneGraph instance to a diagram builder,
+/// connecting the geometry ports.
+/// @param[in,out] builder
+///   Builder to add to.
+/// @param[in] plant (optional)
+///   Constructed plant (e.g. for using a discrete plant). By default, a
+///   continuous plant is used.
+/// @param[in] scene_graph (optional)
+///   Constructed scene graph. If none is provided, one will be created and
+///   used.
+/// @return Pair of the registered plant and scene graph.
+/// @pre `builder` must be non-null.
+template <typename T>
+std::pair<MultibodyPlant<T>*, geometry::SceneGraph<T>*>
+AddMultibodyPlantSceneGraph(
+    systems::DiagramBuilder<T>* builder,
+    std::unique_ptr<MultibodyPlant<T>> plant = nullptr,
+    std::unique_ptr<geometry::SceneGraph<T>> scene_graph = nullptr);
 
 }  // namespace multibody
 }  // namespace drake

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -38,9 +38,6 @@ namespace {
 GTEST_TEST(Box, UnderStiction) {
   DiagramBuilder<double> builder;
 
-  SceneGraph<double>& scene_graph = *builder.AddSystem<SceneGraph>();
-  scene_graph.set_name("scene_graph");
-
   // Length of the simulation, in seconds.
   const double simulation_time = 2.0;
 
@@ -66,8 +63,10 @@ GTEST_TEST(Box, UnderStiction) {
 
   const std::string full_name = FindResourceOrThrow(
       "drake/multibody/plant/test/box.sdf");
-  MultibodyPlant<double>& plant = *builder.AddSystem<MultibodyPlant>(time_step);
-  Parser(&plant, &scene_graph).AddModelFromFile(full_name);
+  auto pair = AddMultibodyPlantSceneGraph(
+      &builder, std::make_unique<MultibodyPlant<double>>(time_step));
+  MultibodyPlant<double>& plant = *pair.first;
+  Parser(&plant).AddModelFromFile(full_name);
 
   // Add gravity to the model.
   plant.AddForceElement<UniformGravityFieldElement>(
@@ -75,7 +74,6 @@ GTEST_TEST(Box, UnderStiction) {
 
   plant.Finalize();  // Done creating the model.
 
-  const MultibodyTree<double>& tree = plant.tree();
   // Set contact parameters.
   plant.set_penetration_allowance(penetration_allowance);
   plant.set_stiction_tolerance(stiction_tolerance);
@@ -88,16 +86,6 @@ GTEST_TEST(Box, UnderStiction) {
 
   // Two input ports: actuation + geometric queries.
   EXPECT_EQ(plant.get_num_input_ports(), 2);
-
-  // Sanity check on the availability of the optional source id before using it.
-  ASSERT_TRUE(!!plant.get_source_id());
-
-  // Wire up MultibodyPlant with SceneGraph.
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
-                  plant.get_geometry_query_input_port());
 
   // And build the Diagram:
   std::unique_ptr<Diagram<double>> diagram = builder.Build();
@@ -135,8 +123,8 @@ GTEST_TEST(Box, UnderStiction) {
       contact_results.contact_info(0);
 
   // Verify the bodies referenced by the contact info.
-  const RigidBody<double>& ground = tree.GetRigidBodyByName("ground");
-  const RigidBody<double>& box = tree.GetRigidBodyByName("box");
+  const Body<double>& ground = plant.GetBodyByName("ground");
+  const Body<double>& box = plant.GetBodyByName("box");
   EXPECT_TRUE(
       (contact_info.bodyA_index() == box.index() &&
        contact_info.bodyB_index() == ground.index()) ||

--- a/multibody/plant/test/box_test.cc
+++ b/multibody/plant/test/box_test.cc
@@ -63,9 +63,8 @@ GTEST_TEST(Box, UnderStiction) {
 
   const std::string full_name = FindResourceOrThrow(
       "drake/multibody/plant/test/box.sdf");
-  auto pair = AddMultibodyPlantSceneGraph(
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(
       &builder, std::make_unique<MultibodyPlant<double>>(time_step));
-  MultibodyPlant<double>& plant = *pair.first;
   Parser(&plant).AddModelFromFile(full_name);
 
   // Add gravity to the model.

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -15,7 +15,7 @@
 namespace drake {
 
 using geometry::SceneGraph;
-using multibody::benchmarks::inclined_plane::MakeInclinedPlanePlant;
+using multibody::benchmarks::inclined_plane::AddInclinedPlaneToPlant;
 using systems::BasicVector;
 using systems::Context;
 using systems::Diagram;
@@ -73,9 +73,6 @@ class InclinedPlaneTest : public ::testing::TestWithParam<bool> {
 TEST_P(InclinedPlaneTest, RollingSphereTest) {
   DiagramBuilder<double> builder;
 
-  SceneGraph<double>& scene_graph = *builder.AddSystem<SceneGraph>();
-  scene_graph.set_name("scene_graph");
-
   // The target accuracy determines the size of the actual time steps taken
   // whenever a variable time step integrator is used.
   const double target_accuracy = 1.0e-6;
@@ -91,26 +88,20 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   const CoulombFriction<double> surface_friction(
       1.0 /* static friction */, 0.5 /* dynamic friction */);
 
-  MultibodyPlant<double>& plant = *builder.AddSystem(MakeInclinedPlanePlant(
-      radius, mass, slope, surface_friction, g, time_step_, &scene_graph));
-  const MultibodyTree<double>& tree = plant.tree();
+  auto pair = AddMultibodyPlantSceneGraph(
+      &builder, std::make_unique<MultibodyPlant<double>>(time_step_));
+  MultibodyPlant<double>& plant = *pair.first;
+  AddInclinedPlaneToPlant(
+      radius, mass, slope, surface_friction, g, &plant);
+  plant.Finalize();
   // Set how much penetration (in meters) we are willing to accept.
   plant.set_penetration_allowance(penetration_allowance_);
   plant.set_stiction_tolerance(stiction_tolerance_);
-  const RigidBody<double>& ball = tree.GetRigidBodyByName("Ball");
+  const RigidBody<double>& ball = plant.GetRigidBodyByName("Ball");
 
   // Sanity check for the model's size.
   DRAKE_DEMAND(plant.num_velocities() == 6);
   DRAKE_DEMAND(plant.num_positions() == 7);
-
-  // Sanity check on the availability of the optional source id before using it.
-  DRAKE_DEMAND(!!plant.get_source_id());
-
-  builder.Connect(
-      plant.get_geometry_poses_output_port(),
-      scene_graph.get_source_pose_port(plant.get_source_id().value()));
-  builder.Connect(scene_graph.get_query_output_port(),
-                  plant.get_geometry_query_input_port());
 
   // And build the Diagram:
   std::unique_ptr<Diagram<double>> diagram = builder.Build();
@@ -124,7 +115,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 
   // This will set a default initial condition with the sphere located at
   // p_WBcm = (0; 0; 0) and zero spatial velocity.
-  tree.SetDefaultContext(&plant_context);
+  plant.SetDefaultContext(&plant_context);
 
   Simulator<double> simulator(*diagram, std::move(diagram_context));
   IntegratorBase<double>* integrator = simulator.get_mutable_integrator();
@@ -135,10 +126,10 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
 
   // Compute the kinetic energy of B (in frame W) from V_WB.
   const SpatialVelocity<double>& V_WB =
-      tree.EvalBodySpatialVelocityInWorld(plant_context, ball);
+      plant.EvalBodySpatialVelocityInWorld(plant_context, ball);
   const SpatialInertia<double> M_BBo_B = ball.default_spatial_inertia();
   const Isometry3<double>& X_WB =
-      tree.EvalBodyPoseInWorld(plant_context, ball);
+      plant.EvalBodyPoseInWorld(plant_context, ball);
   const drake::math::RotationMatrix<double> R_WB(X_WB.linear());
   const SpatialInertia<double> M_BBo_W = M_BBo_B.ReExpress(R_WB);
   const double ke_WB = 0.5 * V_WB.dot(M_BBo_W * V_WB);
@@ -158,7 +149,7 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   const double angular_velocity_expected = speed_expected / radius;
 
   // Verify the plant's potential energy matches the analytical calculation.
-  const double Ve = tree.CalcPotentialEnergy(plant_context);
+  const double Ve = plant.CalcPotentialEnergy(plant_context);
   EXPECT_NEAR(-Ve, ke_WB_expected, std::numeric_limits<double>::epsilon());
 
   // Verify the relative errors. For the continuous model of the plant errors

--- a/multibody/plant/test/inclined_plane_test.cc
+++ b/multibody/plant/test/inclined_plane_test.cc
@@ -88,9 +88,8 @@ TEST_P(InclinedPlaneTest, RollingSphereTest) {
   const CoulombFriction<double> surface_friction(
       1.0 /* static friction */, 0.5 /* dynamic friction */);
 
-  auto pair = AddMultibodyPlantSceneGraph(
+  MultibodyPlant<double>& plant = AddMultibodyPlantSceneGraph(
       &builder, std::make_unique<MultibodyPlant<double>>(time_step_));
-  MultibodyPlant<double>& plant = *pair.first;
   AddInclinedPlaneToPlant(
       radius, mass, slope, surface_friction, g, &plant);
   plant.Finalize();


### PR DESCRIPTION
I have a few motivations here:

(1) Give users reference(s) by default (but still support the `tie`-to-pointers case).
(2) Give users meaningful names (not `.first`).
(3) Encourage users to only deal with the `plant` reference, most of the time.
(4) Provide a jumping-off point for API deprecation and compatibility rework.  (For example, we could decide to stop returning the scene_graph, and offer `plant.get_scene_graph()` in the future, by deprecating the scene_graph public member field and `tie` sugar.)