### PR TITLE
Fixed sdf frames to match DOPE alignment

### DIFF
--- a/manipulation/models/ycb/sdf/003_cracker_box.sdf
+++ b/manipulation/models/ycb/sdf/003_cracker_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_cracker">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0 </pose>
+      <pose frame=''>-0.014 0.103 0.013 1.57 -1.57 0</pose>
       <mass>0.411</mass>
         <inertia>
           <ixx>0.001736</ixx>
@@ -24,7 +24,7 @@
     </inertial>
 
     <visual name='base_link_cracker'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.014 0.103 0.013 1.57 -1.57 0</pose>
       <geometry>
         <mesh>
           <uri>../meshes/003_cracker_box_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/004_sugar_box.sdf
+++ b/manipulation/models/ycb/sdf/004_sugar_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_sugar">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
       <mass>0.514000</mass>
         <inertia>
           <ixx>0.001418</ixx>
@@ -24,7 +24,7 @@
     </inertial>
 
     <visual name='base_link_sugar'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.018  0.088  0.0039 -0.77 -1.52 2.36</pose>
       <geometry>
         <mesh>
           <uri>../meshes/004_sugar_box_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
+++ b/manipulation/models/ycb/sdf/005_tomato_soup_can.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_soup">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
       <mass>0.349000</mass>
         <inertia>
           <ixx>0.000402</ixx>
@@ -24,7 +24,7 @@
     </inertial>
 
     <visual name='base_link_soup'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.0018  0.051 -0.084 1.57 0.13 0.0</pose>
       <geometry>
         <mesh>
           <uri>../meshes/005_tomato_soup_can_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
+++ b/manipulation/models/ycb/sdf/006_mustard_bottle.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_mustard">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
       <mass>0.603000</mass>
         <inertia>
           <ixx>0.002009</ixx>
@@ -23,7 +23,7 @@
         </inertia>
     </inertial>
     <visual name='base_link_mustard'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>0.0049 0.092 0.027 1.57 -0.40 0.0</pose>
       <geometry>
         <mesh>
           <uri>../meshes/006_mustard_bottle_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/009_gelatin_box.sdf
+++ b/manipulation/models/ycb/sdf/009_gelatin_box.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_gelatin">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
       <mass>0.097000</mass>
         <inertia>
           <ixx>0.000050</ixx>
@@ -24,7 +24,7 @@
     </inertial>
 
     <visual name='base_link_gelatin'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>-0.0029 0.024 -0.015 -0.0085 -0.002 1.34</pose>
       <geometry>
         <mesh>
           <uri>../meshes/009_gelatin_box_textured.obj</uri>

--- a/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
+++ b/manipulation/models/ycb/sdf/010_potted_meat_can.sdf
@@ -11,7 +11,7 @@
   -->
   <link name="base_link_meat">
     <inertial>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>0.034 0.039 0.025 1.57 0.052 0.0</pose>
       <mass>0.370000</mass>
         <inertia>
           <ixx>0.000317</ixx>
@@ -24,7 +24,7 @@
     </inertial>
 
     <visual name='base_link_meat'>
-      <pose frame=''>0 0 0 0 0 0</pose>
+      <pose frame=''>0.034 0.039 0.025 1.57 0.052 0.0</pose>
       <geometry>
         <mesh>
           <uri>../meshes/010_potted_meat_can_textured.obj</uri>


### PR DESCRIPTION
The frames of all the objects were changed so they use the original YCB .obj files but follow the DOPE alignment axes. They have been tested in both drake visualizer and meshcat.