### PR TITLE
[wip] fix build and add test

### DIFF
--- a/bindings/pydrake/test/geometry_test.py
+++ b/bindings/pydrake/test/geometry_test.py
@@ -584,11 +584,11 @@ class TestGeometry(unittest.TestCase):
         ...
 
     def test_render_engine_api(self):
-        class DummyRenderEngine(mut.RenderEngine):
+        class DummyRenderEngine(mut.render.RenderEngine):
             """Mirror of C++ DummyRenderEngine."""
 
             def __init__(self, render_label=None):
-                mut.RenderEngine.__init__(self, render_label)
+                mut.render.RenderEngine.__init__(self)
                 self._force_accept = False
                 self._registered_geometries = set()
                 self._updated_ids = {}
@@ -597,9 +597,26 @@ class TestGeometry(unittest.TestCase):
                 self._simple_color_count = 0
                 self._simple_depth_count = 0
                 self._simple_label_count = 0
-                self._color_props = mut.render.CameraProperties()
-                self._depth_props = mut.render.DepthCameraProperties()
-                self._label_props = mut.render.CameraProperties()
+                self._color_props = mut.render.CameraProperties(
+                    width=320,
+                    height=240,
+                    fov_y=pi / 6,
+                    renderer_name="test_renderer",
+                )
+                self._depth_props = mut.render.DepthCameraProperties(
+                    width=320,
+                    height=240,
+                    fov_y=pi / 6,
+                    renderer_name="test_renderer",
+                    z_near=0.1,
+                    z_far=5.0,
+                )
+                self._label_props = mut.render.CameraProperties(
+                    width=320,
+                    height=240,
+                    fov_y=pi / 6,
+                    renderer_name="test_renderer",
+                )
 
             def UpdateViewPoint(self, X_WC):
                 self._X_WC = X_WC


### PR DESCRIPTION
Fix lots of build problems but not all. Currently remaining errors are related to `doc` and some protected functions:

```
ERROR: /home/duynguyen/git/drake/bindings/pydrake/BUILD.bazel:128:1: C++ compilation of rule '//bindings/pydrake:geometry.so' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 341 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
bindings/pydrake/geometry_py.cc: In function 'void drake::pydrake::{anonymous}::def_geometry_render(pybind11::module)':
bindings/pydrake/geometry_py.cc:171:53: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'doc_1args'
         .def(py::init<Class const&>(), cls_doc.ctor.doc_1args)
                                                     ^~~~~~~~~
bindings/pydrake/geometry_py.cc:172:55: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'doc_2args'
         .def(py::init<double, double>(), cls_doc.ctor.doc_2args)
                                                       ^~~~~~~~~
bindings/pydrake/geometry_py.cc:180:47: error: 'cls_doc' was not declared in this scope
     py::class_<Class>(m, "ColorRenderCamera", cls_doc.doc)
                                               ^~~~~~~
bindings/pydrake/geometry_py.cc:286:38: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'doc'
             cls_doc.RenderColorImage.doc)
                                      ^~~
bindings/pydrake/geometry_py.cc:291:38: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'doc'
             cls_doc.RenderDepthImage.doc)
                                      ^~~
bindings/pydrake/geometry_py.cc:296:38: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'doc'
             cls_doc.RenderLabelImage.doc)
                                      ^~~
bindings/pydrake/geometry_py.cc:337:40: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'GetRenderLabelOrThrow'; did you mean 'RenderLabel'?
             py::arg("properties"), doc.GetRenderLabelOrThrow.doc)
                                        ^~~~~~~~~~~~~~~~~~~~~
                                        RenderLabel
bindings/pydrake/geometry_py.cc:341:35: error: 'const struct<unnamed struct>::<unnamed struct>::<unnamed struct>::<unnamed>' has no member named 'LabelFromColor'
             py::arg("color"), doc.LabelFromColor.doc)
                                   ^~~~~~~~~~~~~~
bindings/pydrake/geometry_py.cc:357:48: error: 'static void drake::geometry::render::RenderEngine::ThrowIfInvalid(const drake::systems::sensors::CameraInfo&, const ImageType*, const char*) [with ImageType = drake::systems::sensors::Image<(drake::systems::sensors::PixelType)2>]' is protected within this context
                 &PyRenderEngine::ThrowIfInvalid),
                                                ^
In file included from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_state.h:23:0,
                 from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_visualization.h:8,
                 from bindings/pydrake/geometry_py.cc:21:
bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/render/render_engine.h:420:15: note: declared protected here
   static void ThrowIfInvalid(const systems::sensors::CameraInfo& intrinsics,
               ^~~~~~~~~~~~~~
bindings/pydrake/geometry_py.cc:363:48: error: 'static void drake::geometry::render::RenderEngine::ThrowIfInvalid(const drake::systems::sensors::CameraInfo&, const ImageType*, const char*) [with ImageType = drake::systems::sensors::Image<(drake::systems::sensors::PixelType)6>]' is protected within this context
                 &PyRenderEngine::ThrowIfInvalid),
                                                ^
In file included from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_state.h:23:0,
                 from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_visualization.h:8,
                 from bindings/pydrake/geometry_py.cc:21:
bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/render/render_engine.h:420:15: note: declared protected here
   static void ThrowIfInvalid(const systems::sensors::CameraInfo& intrinsics,
               ^~~~~~~~~~~~~~
bindings/pydrake/geometry_py.cc:369:48: error: 'static void drake::geometry::render::RenderEngine::ThrowIfInvalid(const drake::systems::sensors::CameraInfo&, const ImageType*, const char*) [with ImageType = drake::systems::sensors::Image<(drake::systems::sensors::PixelType)7>]' is protected within this context
                 &PyRenderEngine::ThrowIfInvalid),
                                                ^
In file included from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_state.h:23:0,
                 from bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/geometry_visualization.h:8,
                 from bindings/pydrake/geometry_py.cc:21:
bazel-out/k8-opt/bin/tools/install/libdrake/_virtual_includes/drake_shared_library/drake/geometry/render/render_engine.h:420:15: note: declared protected here
   static void ThrowIfInvalid(const systems::sensors::CameraInfo& intrinsics,
```